### PR TITLE
feat: implement end-to-end acquisition core slice

### DIFF
--- a/ddd_policy_tracer/__init__.py
+++ b/ddd_policy_tracer/__init__.py
@@ -1,0 +1,8 @@
+from .service_layer import AcquisitionReport, SourceDocumentVersion, get_source_document_versions, ingest_source_documents
+
+__all__ = [
+    "AcquisitionReport",
+    "SourceDocumentVersion",
+    "get_source_document_versions",
+    "ingest_source_documents",
+]

--- a/ddd_policy_tracer/adapters.py
+++ b/ddd_policy_tracer/adapters.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sqlite3
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from uuid import uuid4
+
+from .domain import SourceDocumentVersion
+
+
+class SQLiteSourceDocumentRepository:
+    def __init__(self, sqlite_path: Path) -> None:
+        self._sqlite_path = sqlite_path
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self._sqlite_path)
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS source_document_versions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source_id TEXT NOT NULL,
+                    source_document_id TEXT NOT NULL,
+                    source_url TEXT NOT NULL,
+                    checksum TEXT NOT NULL,
+                    normalized_text TEXT NOT NULL,
+                    raw_content_ref TEXT NOT NULL,
+                    content_type TEXT NOT NULL,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+                )
+                """
+            )
+
+    def get_latest(
+        self,
+        *,
+        source_id: str,
+        source_document_id: str,
+    ) -> SourceDocumentVersion | None:
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT source_id, source_document_id, source_url, checksum, normalized_text, raw_content_ref, content_type
+                FROM source_document_versions
+                WHERE source_id = ? AND source_document_id = ?
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (source_id, source_document_id),
+            ).fetchone()
+
+        if row is None:
+            return None
+
+        return SourceDocumentVersion(*row)
+
+    def add_version(self, version: SourceDocumentVersion) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO source_document_versions
+                (source_id, source_document_id, source_url, checksum, normalized_text, raw_content_ref, content_type)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    version.source_id,
+                    version.source_document_id,
+                    version.source_url,
+                    version.checksum,
+                    version.normalized_text,
+                    version.raw_content_ref,
+                    version.content_type,
+                ),
+            )
+
+    def list_versions(self, *, source_id: str) -> list[SourceDocumentVersion]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT source_id, source_document_id, source_url, checksum, normalized_text, raw_content_ref, content_type
+                FROM source_document_versions
+                WHERE source_id = ?
+                ORDER BY id ASC
+                """,
+                (source_id,),
+            ).fetchall()
+
+        return [SourceDocumentVersion(*row) for row in rows]
+
+
+class DiskArtifactStore:
+    def __init__(self, artifact_dir: Path) -> None:
+        self._artifact_dir = artifact_dir
+        self._artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    def store(self, *, source_document_id: str, content: bytes) -> str:
+        safe_id = source_document_id.replace("://", "_").replace("/", "_").replace("?", "_")
+        file_path = self._artifact_dir / f"{safe_id}_{uuid4().hex}.bin"
+        file_path.write_bytes(content)
+        return str(file_path)
+
+
+def discover_urls_from_sitemap(sitemap_xml: str) -> list[str]:
+    root = ET.fromstring(sitemap_xml)
+    namespace = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    urls = [node.text.strip() for node in root.findall("sm:url/sm:loc", namespace) if node.text]
+    return urls

--- a/ddd_policy_tracer/domain.py
+++ b/ddd_policy_tracer/domain.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+TRACKING_QUERY_KEYS = {
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "utm_id",
+    "gclid",
+    "fbclid",
+}
+
+
+@dataclass(frozen=True)
+class SourceDocumentVersion:
+    source_id: str
+    source_document_id: str
+    source_url: str
+    checksum: str
+    normalized_text: str
+    raw_content_ref: str
+    content_type: str
+
+
+def normalize_source_document_id(raw_url: str) -> str:
+    parts = urlsplit(raw_url.strip())
+    scheme = parts.scheme.lower()
+    netloc = parts.netloc.lower()
+    path = parts.path or "/"
+    if path != "/":
+        path = path.rstrip("/") or "/"
+
+    filtered_query = []
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        if key in TRACKING_QUERY_KEYS:
+            continue
+        if value == "":
+            continue
+        filtered_query.append((key, value))
+
+    query = urlencode(filtered_query, doseq=True)
+    return urlunsplit((scheme, netloc, path, query, ""))
+
+
+def compute_checksum(raw_content: bytes) -> str:
+    return sha256(raw_content).hexdigest()
+
+
+def normalize_text(raw_text: str) -> str:
+    return " ".join(raw_text.split())

--- a/ddd_policy_tracer/service_layer.py
+++ b/ddd_policy_tracer/service_layer.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from .adapters import DiskArtifactStore, SQLiteSourceDocumentRepository, discover_urls_from_sitemap
+from .domain import SourceDocumentVersion, compute_checksum, normalize_source_document_id, normalize_text
+
+
+@dataclass(frozen=True)
+class AcquisitionReport:
+    processed_urls: int
+    ingested_documents: int
+    failed_documents: int
+
+
+def ingest_source_documents(
+    *,
+    source_id: str,
+    sitemap_xml: str,
+    sqlite_path: Path,
+    artifact_dir: Path,
+    fetch_document: Callable[[str], tuple[str, bytes]],
+) -> AcquisitionReport:
+    repository = SQLiteSourceDocumentRepository(sqlite_path)
+    artifact_store = DiskArtifactStore(artifact_dir)
+
+    processed_urls = 0
+    ingested_documents = 0
+    failed_documents = 0
+
+    for source_url in discover_urls_from_sitemap(sitemap_xml):
+        processed_urls += 1
+        source_document_id = normalize_source_document_id(source_url)
+
+        try:
+            content_type, raw_content = fetch_document(source_url)
+            extracted_text = raw_content.decode("utf-8", errors="ignore")
+            normalized = normalize_text(extracted_text)
+            if not normalized:
+                raise ValueError("normalized_text is empty")
+
+            checksum = compute_checksum(raw_content)
+            latest_version = repository.get_latest(
+                source_id=source_id,
+                source_document_id=source_document_id,
+            )
+            if latest_version is not None and latest_version.checksum == checksum:
+                continue
+
+            raw_content_ref = artifact_store.store(
+                source_document_id=source_document_id,
+                content=raw_content,
+            )
+            version = SourceDocumentVersion(
+                source_id=source_id,
+                source_document_id=source_document_id,
+                source_url=source_url,
+                checksum=checksum,
+                normalized_text=normalized,
+                raw_content_ref=raw_content_ref,
+                content_type=content_type,
+            )
+            repository.add_version(version)
+            ingested_documents += 1
+        except Exception:
+            failed_documents += 1
+
+    return AcquisitionReport(
+        processed_urls=processed_urls,
+        ingested_documents=ingested_documents,
+        failed_documents=failed_documents,
+    )
+
+
+def get_source_document_versions(
+    *,
+    sqlite_path: Path,
+    source_id: str,
+) -> list[SourceDocumentVersion]:
+    repository = SQLiteSourceDocumentRepository(sqlite_path)
+    return repository.list_versions(source_id=source_id)

--- a/tests/integration/test_acquisition_core.py
+++ b/tests/integration/test_acquisition_core.py
@@ -39,3 +39,76 @@ def test_ingest_from_sitemap_persists_first_source_document_version(tmp_path: Pa
     assert version.normalized_text == "This is a report about policy reform."
     assert version.raw_content_ref.startswith(str(artifact_dir))
     assert Path(version.raw_content_ref).exists()
+
+
+def test_reprocessing_same_unchanged_url_is_idempotent(tmp_path: Path) -> None:
+    sqlite_path = tmp_path / "acquisition.db"
+    artifact_dir = tmp_path / "artifacts"
+    sitemap_xml = """
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>https://australiainstitute.org.au/report-1?utm_source=newsletter</loc></url>
+    </urlset>
+    """.strip()
+
+    def fetch_document(_: str) -> tuple[str, bytes]:
+        return "text/plain", b"Unchanged report body."
+
+    first_report = ingest_source_documents(
+        source_id="australia_institute",
+        sitemap_xml=sitemap_xml,
+        sqlite_path=sqlite_path,
+        artifact_dir=artifact_dir,
+        fetch_document=fetch_document,
+    )
+    second_report = ingest_source_documents(
+        source_id="australia_institute",
+        sitemap_xml=sitemap_xml,
+        sqlite_path=sqlite_path,
+        artifact_dir=artifact_dir,
+        fetch_document=fetch_document,
+    )
+
+    assert first_report.ingested_documents == 1
+    assert second_report.ingested_documents == 0
+
+    versions = get_source_document_versions(sqlite_path=sqlite_path, source_id="australia_institute")
+    assert len(versions) == 1
+
+
+def test_checksum_change_appends_new_version(tmp_path: Path) -> None:
+    sqlite_path = tmp_path / "acquisition.db"
+    artifact_dir = tmp_path / "artifacts"
+    sitemap_xml = """
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>https://australiainstitute.org.au/report-1</loc></url>
+    </urlset>
+    """.strip()
+
+    payloads = [
+        b"Version 1 content.",
+        b"Version 2 content with updates.",
+    ]
+
+    def fetch_document(_: str) -> tuple[str, bytes]:
+        return "text/plain", payloads.pop(0)
+
+    ingest_source_documents(
+        source_id="australia_institute",
+        sitemap_xml=sitemap_xml,
+        sqlite_path=sqlite_path,
+        artifact_dir=artifact_dir,
+        fetch_document=fetch_document,
+    )
+    second_report = ingest_source_documents(
+        source_id="australia_institute",
+        sitemap_xml=sitemap_xml,
+        sqlite_path=sqlite_path,
+        artifact_dir=artifact_dir,
+        fetch_document=fetch_document,
+    )
+
+    assert second_report.ingested_documents == 1
+
+    versions = get_source_document_versions(sqlite_path=sqlite_path, source_id="australia_institute")
+    assert len(versions) == 2
+    assert versions[0].checksum != versions[1].checksum


### PR DESCRIPTION
## Summary
- implement the first acquisition vertical slice from sitemap URL discovery through fetch, text normalization, and versioned source document persistence
- add SQLite and disk adapters plus domain helpers for URL identity normalization and checksum-based idempotent versioning
- expand integration coverage for first-ingest persistence, unchanged reprocessing idempotency, and append-only version creation on checksum change

Fixes #2