### PR TITLE
feat: add acquisition run terminal statuses

### DIFF
--- a/ddd_policy_tracer/service_layer.py
+++ b/ddd_policy_tracer/service_layer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Literal
 
 from .adapters import DiskArtifactStore, SQLiteSourceDocumentRepository, discover_urls_from_sitemap
 from .domain import SourceDocumentVersion, compute_checksum, normalize_source_document_id, normalize_text
@@ -13,6 +13,7 @@ class AcquisitionReport:
     processed_urls: int
     ingested_documents: int
     failed_documents: int
+    run_status: Literal["completed", "completed_with_failures", "failed"]
 
 
 def ingest_source_documents(
@@ -67,10 +68,18 @@ def ingest_source_documents(
         except Exception:
             failed_documents += 1
 
+    if failed_documents == 0:
+        run_status: Literal["completed", "completed_with_failures", "failed"] = "completed"
+    elif ingested_documents == 0:
+        run_status = "failed"
+    else:
+        run_status = "completed_with_failures"
+
     return AcquisitionReport(
         processed_urls=processed_urls,
         ingested_documents=ingested_documents,
         failed_documents=failed_documents,
+        run_status=run_status,
     )
 
 

--- a/tests/integration/test_acquisition_core.py
+++ b/tests/integration/test_acquisition_core.py
@@ -27,6 +27,7 @@ def test_ingest_from_sitemap_persists_first_source_document_version(tmp_path: Pa
     assert report.processed_urls == 1
     assert report.ingested_documents == 1
     assert report.failed_documents == 0
+    assert report.run_status == "completed"
 
     versions = get_source_document_versions(
         sqlite_path=sqlite_path,
@@ -112,3 +113,59 @@ def test_checksum_change_appends_new_version(tmp_path: Path) -> None:
     versions = get_source_document_versions(sqlite_path=sqlite_path, source_id="australia_institute")
     assert len(versions) == 2
     assert versions[0].checksum != versions[1].checksum
+
+
+def test_run_status_is_completed_with_failures_for_mixed_outcomes(tmp_path: Path) -> None:
+    sqlite_path = tmp_path / "acquisition.db"
+    artifact_dir = tmp_path / "artifacts"
+    sitemap_xml = """
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>https://australiainstitute.org.au/report-ok</loc></url>
+      <url><loc>https://australiainstitute.org.au/report-fail</loc></url>
+    </urlset>
+    """.strip()
+
+    def fetch_document(url: str) -> tuple[str, bytes]:
+        if "report-fail" in url:
+            raise RuntimeError("temporary fetch failure")
+        return "text/plain", b"Healthy document content."
+
+    report = ingest_source_documents(
+        source_id="australia_institute",
+        sitemap_xml=sitemap_xml,
+        sqlite_path=sqlite_path,
+        artifact_dir=artifact_dir,
+        fetch_document=fetch_document,
+    )
+
+    assert report.processed_urls == 2
+    assert report.ingested_documents == 1
+    assert report.failed_documents == 1
+    assert report.run_status == "completed_with_failures"
+
+
+def test_run_status_is_failed_when_all_urls_fail(tmp_path: Path) -> None:
+    sqlite_path = tmp_path / "acquisition.db"
+    artifact_dir = tmp_path / "artifacts"
+    sitemap_xml = """
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>https://australiainstitute.org.au/report-a</loc></url>
+      <url><loc>https://australiainstitute.org.au/report-b</loc></url>
+    </urlset>
+    """.strip()
+
+    def fetch_document(_: str) -> tuple[str, bytes]:
+        raise RuntimeError("network unavailable")
+
+    report = ingest_source_documents(
+        source_id="australia_institute",
+        sitemap_xml=sitemap_xml,
+        sqlite_path=sqlite_path,
+        artifact_dir=artifact_dir,
+        fetch_document=fetch_document,
+    )
+
+    assert report.processed_urls == 2
+    assert report.ingested_documents == 0
+    assert report.failed_documents == 2
+    assert report.run_status == "failed"


### PR DESCRIPTION
## Summary
- add run-level terminal status derivation to acquisition reporting with `completed`, `completed_with_failures`, and `failed`
- preserve per-URL independent processing while reflecting mixed and all-failure batches in aggregate outcomes
- add integration coverage for successful, mixed-outcome, and all-failure run status behavior

Fixes #3