### PR TITLE
feat: add compliance-aware retries for acquisition fetch

### DIFF
--- a/ddd_policy_tracer/service_layer.py
+++ b/ddd_policy_tracer/service_layer.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import inspect
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Literal
+from typing import Callable, Literal, Sequence
 
 from .adapters import DiskArtifactStore, SQLiteSourceDocumentRepository, discover_urls_from_sitemap
 from .domain import SourceDocumentVersion, compute_checksum, normalize_source_document_id, normalize_text
@@ -13,6 +15,9 @@ class AcquisitionReport:
     processed_urls: int
     ingested_documents: int
     failed_documents: int
+    skipped_urls: int
+    retry_attempts: int
+    document_failures: tuple[str, ...]
     run_status: Literal["completed", "completed_with_failures", "failed"]
 
 
@@ -22,7 +27,12 @@ def ingest_source_documents(
     sitemap_xml: str,
     sqlite_path: Path,
     artifact_dir: Path,
-    fetch_document: Callable[[str], tuple[str, bytes]],
+    fetch_document: Callable[..., tuple[str, bytes]],
+    user_agent: str = "ddd-policy-tracer/0.1",
+    is_allowed_by_robots: Callable[[str, str], bool] | None = None,
+    max_retries: int = 2,
+    backoff_seconds: Sequence[float] = (0.25, 0.5),
+    sleep_fn: Callable[[float], None] = time.sleep,
 ) -> AcquisitionReport:
     repository = SQLiteSourceDocumentRepository(sqlite_path)
     artifact_store = DiskArtifactStore(artifact_dir)
@@ -30,13 +40,31 @@ def ingest_source_documents(
     processed_urls = 0
     ingested_documents = 0
     failed_documents = 0
+    skipped_urls = 0
+    retry_attempts = 0
+    document_failures: list[str] = []
+
+    robots_checker = is_allowed_by_robots or (lambda _url, _ua: True)
 
     for source_url in discover_urls_from_sitemap(sitemap_xml):
         processed_urls += 1
+
+        if not robots_checker(source_url, user_agent):
+            skipped_urls += 1
+            continue
+
         source_document_id = normalize_source_document_id(source_url)
 
         try:
-            content_type, raw_content = fetch_document(source_url)
+            content_type, raw_content, used_retries = _fetch_with_retries(
+                fetch_document=fetch_document,
+                source_url=source_url,
+                user_agent=user_agent,
+                max_retries=max_retries,
+                backoff_seconds=backoff_seconds,
+                sleep_fn=sleep_fn,
+            )
+            retry_attempts += used_retries
             extracted_text = raw_content.decode("utf-8", errors="ignore")
             normalized = normalize_text(extracted_text)
             if not normalized:
@@ -65,8 +93,9 @@ def ingest_source_documents(
             )
             repository.add_version(version)
             ingested_documents += 1
-        except Exception:
+        except Exception as exc:
             failed_documents += 1
+            document_failures.append(f"{source_url}: {exc}")
 
     if failed_documents == 0:
         run_status: Literal["completed", "completed_with_failures", "failed"] = "completed"
@@ -79,6 +108,9 @@ def ingest_source_documents(
         processed_urls=processed_urls,
         ingested_documents=ingested_documents,
         failed_documents=failed_documents,
+        skipped_urls=skipped_urls,
+        retry_attempts=retry_attempts,
+        document_failures=tuple(document_failures),
         run_status=run_status,
     )
 
@@ -90,3 +122,44 @@ def get_source_document_versions(
 ) -> list[SourceDocumentVersion]:
     repository = SQLiteSourceDocumentRepository(sqlite_path)
     return repository.list_versions(source_id=source_id)
+
+
+def _call_fetch_document(
+    *,
+    fetch_document: Callable[..., tuple[str, bytes]],
+    source_url: str,
+    user_agent: str,
+) -> tuple[str, bytes]:
+    signature = inspect.signature(fetch_document)
+    if len(signature.parameters) >= 2:
+        return fetch_document(source_url, user_agent)
+    return fetch_document(source_url)
+
+
+def _fetch_with_retries(
+    *,
+    fetch_document: Callable[..., tuple[str, bytes]],
+    source_url: str,
+    user_agent: str,
+    max_retries: int,
+    backoff_seconds: Sequence[float],
+    sleep_fn: Callable[[float], None],
+) -> tuple[str, bytes, int]:
+    retries_used = 0
+
+    while True:
+        try:
+            content_type, raw_content = _call_fetch_document(
+                fetch_document=fetch_document,
+                source_url=source_url,
+                user_agent=user_agent,
+            )
+            return content_type, raw_content, retries_used
+        except (TimeoutError, ConnectionError):
+            if retries_used >= max_retries:
+                raise
+
+            delay_index = min(retries_used, max(0, len(backoff_seconds) - 1))
+            delay = backoff_seconds[delay_index] if backoff_seconds else 0.0
+            sleep_fn(delay)
+            retries_used += 1

--- a/tests/integration/test_acquisition_core.py
+++ b/tests/integration/test_acquisition_core.py
@@ -169,3 +169,119 @@ def test_run_status_is_failed_when_all_urls_fail(tmp_path: Path) -> None:
     assert report.ingested_documents == 0
     assert report.failed_documents == 2
     assert report.run_status == "failed"
+
+
+def test_compliance_blocks_disallowed_url_and_uses_configured_user_agent(tmp_path: Path) -> None:
+    sqlite_path = tmp_path / "acquisition.db"
+    artifact_dir = tmp_path / "artifacts"
+    sitemap_xml = """
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>https://australiainstitute.org.au/allowed-report</loc></url>
+      <url><loc>https://australiainstitute.org.au/blocked-report</loc></url>
+    </urlset>
+    """.strip()
+
+    fetched_urls: list[str] = []
+    seen_user_agents: list[str] = []
+
+    def fetch_document(url: str, user_agent: str) -> tuple[str, bytes]:
+        fetched_urls.append(url)
+        seen_user_agents.append(user_agent)
+        return "text/plain", b"Compliant content."
+
+    def is_allowed_by_robots(url: str, _: str) -> bool:
+        return "blocked" not in url
+
+    report = ingest_source_documents(
+        source_id="australia_institute",
+        sitemap_xml=sitemap_xml,
+        sqlite_path=sqlite_path,
+        artifact_dir=artifact_dir,
+        fetch_document=fetch_document,
+        user_agent="policy-tracer/0.1",
+        is_allowed_by_robots=is_allowed_by_robots,
+    )
+
+    assert fetched_urls == ["https://australiainstitute.org.au/allowed-report"]
+    assert seen_user_agents == ["policy-tracer/0.1"]
+    assert report.processed_urls == 2
+    assert report.ingested_documents == 1
+    assert report.failed_documents == 0
+    assert report.skipped_urls == 1
+
+
+def test_transient_failure_is_retried_and_observable(tmp_path: Path) -> None:
+    sqlite_path = tmp_path / "acquisition.db"
+    artifact_dir = tmp_path / "artifacts"
+    sitemap_xml = """
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>https://australiainstitute.org.au/retry-report</loc></url>
+    </urlset>
+    """.strip()
+
+    attempts = 0
+
+    def fetch_document(_: str) -> tuple[str, bytes]:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise TimeoutError("temporary timeout")
+        return "text/plain", b"Recovered after retries."
+
+    sleep_calls: list[float] = []
+
+    report = ingest_source_documents(
+        source_id="australia_institute",
+        sitemap_xml=sitemap_xml,
+        sqlite_path=sqlite_path,
+        artifact_dir=artifact_dir,
+        fetch_document=fetch_document,
+        max_retries=2,
+        backoff_seconds=(0.1, 0.2),
+        sleep_fn=sleep_calls.append,
+    )
+
+    assert attempts == 3
+    assert sleep_calls == [0.1, 0.2]
+    assert report.ingested_documents == 1
+    assert report.failed_documents == 0
+    assert report.retry_attempts == 2
+
+
+def test_terminal_failure_records_actionable_reason_after_retry_budget_exhausted(
+    tmp_path: Path,
+) -> None:
+    sqlite_path = tmp_path / "acquisition.db"
+    artifact_dir = tmp_path / "artifacts"
+    sitemap_xml = """
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>https://australiainstitute.org.au/fails-hard</loc></url>
+    </urlset>
+    """.strip()
+
+    attempts = 0
+
+    def fetch_document(_: str) -> tuple[str, bytes]:
+        nonlocal attempts
+        attempts += 1
+        raise TimeoutError("request timeout")
+
+    report = ingest_source_documents(
+        source_id="australia_institute",
+        sitemap_xml=sitemap_xml,
+        sqlite_path=sqlite_path,
+        artifact_dir=artifact_dir,
+        fetch_document=fetch_document,
+        max_retries=1,
+        backoff_seconds=(0.01,),
+        sleep_fn=lambda _seconds: None,
+    )
+
+    assert attempts == 2
+    assert report.ingested_documents == 0
+    assert report.failed_documents == 1
+    assert report.run_status == "failed"
+    assert report.retry_attempts == 0
+    assert len(report.document_failures) == 1
+    assert "fails-hard" in report.document_failures[0]
+    assert "request timeout" in report.document_failures[0]


### PR DESCRIPTION
## Summary
- add compliance controls to acquisition fetch flow with configurable user-agent and robots-style allow checks that skip disallowed URLs
- add bounded retry/backoff behavior for transient fetch failures and keep per-url processing independent
- surface observability in acquisition outcomes via skipped URL counts, retry attempt totals, and actionable per-document failure reasons

Fixes #4