### PR TITLE
feat: add operator CLI for manual acquisition runs

### DIFF
--- a/ddd_policy_tracer/__init__.py
+++ b/ddd_policy_tracer/__init__.py
@@ -1,9 +1,11 @@
 from .domain import SourceDocumentVersion
 from .service_layer import AcquisitionReport, get_source_document_versions, ingest_source_documents
+from .cli import run_cli
 
 __all__ = [
     "AcquisitionReport",
     "SourceDocumentVersion",
     "get_source_document_versions",
     "ingest_source_documents",
+    "run_cli",
 ]

--- a/ddd_policy_tracer/cli.py
+++ b/ddd_policy_tracer/cli.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Callable, Sequence, TextIO
+
+from .service_layer import ingest_source_documents
+
+
+def run_cli(
+    argv: Sequence[str],
+    *,
+    fetch_document: Callable[..., tuple[str, bytes]],
+    stdout: TextIO,
+) -> int:
+    parser = argparse.ArgumentParser(prog="ddd-policy-tracer")
+    subparsers = parser.add_subparsers(dest="command")
+
+    acquire_parser = subparsers.add_parser("acquire")
+    acquire_parser.add_argument("--source", required=True)
+    acquire_parser.add_argument("--sitemap-xml-path", required=True)
+    acquire_parser.add_argument("--sqlite-path", required=True)
+    acquire_parser.add_argument("--artifact-dir", required=True)
+    acquire_parser.add_argument("--limit", type=int, default=None)
+    acquire_parser.add_argument("--dry-run", action="store_true")
+
+    args = parser.parse_args(list(argv))
+
+    if args.command != "acquire":
+        parser.print_help(file=stdout)
+        return 2
+
+    sitemap_xml = Path(args.sitemap_xml_path).read_text(encoding="utf-8")
+
+    if args.dry_run:
+        discovered = _discover_urls_with_limit(sitemap_xml=sitemap_xml, limit=args.limit)
+        stdout.write(
+            f"dry_run source={args.source} discovered_urls={len(discovered)} limit={args.limit}\n"
+        )
+        return 0
+
+    report = ingest_source_documents(
+        source_id=args.source,
+        sitemap_xml=sitemap_xml,
+        sqlite_path=Path(args.sqlite_path),
+        artifact_dir=Path(args.artifact_dir),
+        fetch_document=fetch_document,
+        limit=args.limit,
+    )
+
+    stdout.write(
+        " ".join(
+            [
+                f"source={args.source}",
+                f"processed_urls={report.processed_urls}",
+                f"ingested_documents={report.ingested_documents}",
+                f"failed_documents={report.failed_documents}",
+                f"skipped_urls={report.skipped_urls}",
+                f"run_status={report.run_status}",
+            ]
+        )
+        + "\n"
+    )
+    return 0
+
+
+def _discover_urls_with_limit(*, sitemap_xml: str, limit: int | None) -> list[str]:
+    from .adapters import discover_urls_from_sitemap
+
+    urls = discover_urls_from_sitemap(sitemap_xml)
+    if limit is not None:
+        return urls[: max(0, limit)]
+    return urls

--- a/ddd_policy_tracer/service_layer.py
+++ b/ddd_policy_tracer/service_layer.py
@@ -51,6 +51,7 @@ def ingest_source_documents(
     max_retries: int = 2,
     backoff_seconds: Sequence[float] = (0.25, 0.5),
     sleep_fn: Callable[[float], None] = time.sleep,
+    limit: int | None = None,
 ) -> AcquisitionReport:
     repository = SQLiteSourceDocumentRepository(sqlite_path)
     artifact_store = DiskArtifactStore(artifact_dir)
@@ -72,7 +73,11 @@ def ingest_source_documents(
 
     robots_checker = is_allowed_by_robots or (lambda _url, _ua: True)
 
-    for source_url in discover_urls_from_sitemap(sitemap_xml):
+    discovered_urls = discover_urls_from_sitemap(sitemap_xml)
+    if limit is not None:
+        discovered_urls = discovered_urls[: max(0, limit)]
+
+    for source_url in discovered_urls:
         processed_urls += 1
 
         if not robots_checker(source_url, user_agent):

--- a/main.py
+++ b/main.py
@@ -1,6 +1,24 @@
-def main() -> None:
-    print("Hello from ddd-policy-tracer!")
+from __future__ import annotations
+
+import sys
+from typing import Sequence
+from urllib.request import Request, urlopen
+
+from ddd_policy_tracer.cli import run_cli
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    return run_cli(args, fetch_document=fetch_document_over_http, stdout=sys.stdout)
+
+
+def fetch_document_over_http(url: str, user_agent: str) -> tuple[str, bytes]:
+    request = Request(url, headers={"User-Agent": user_agent})
+    with urlopen(request, timeout=30) as response:
+        content_type = response.headers.get_content_type() or "application/octet-stream"
+        payload = response.read()
+    return content_type, payload
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/integration/test_operator_cli.py
+++ b/tests/integration/test_operator_cli.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+from ddd_policy_tracer import get_source_document_versions
+from ddd_policy_tracer.cli import run_cli
+
+
+def test_cli_runs_manual_acquisition_for_source_and_prints_result(tmp_path: Path) -> None:
+    sqlite_path = tmp_path / "acquisition.db"
+    artifact_dir = tmp_path / "artifacts"
+    sitemap_path = tmp_path / "sitemap.xml"
+    sitemap_path.write_text(
+        """
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url><loc>https://australiainstitute.org.au/report-1</loc></url>
+        </urlset>
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    output = StringIO()
+
+    exit_code = run_cli(
+        [
+            "acquire",
+            "--source",
+            "australia_institute",
+            "--sitemap-xml-path",
+            str(sitemap_path),
+            "--sqlite-path",
+            str(sqlite_path),
+            "--artifact-dir",
+            str(artifact_dir),
+        ],
+        fetch_document=lambda _url: ("text/plain", b"CLI ingestion content"),
+        stdout=output,
+    )
+
+    assert exit_code == 0
+    rendered = output.getvalue()
+    assert "source=australia_institute" in rendered
+    assert "run_status=completed" in rendered
+
+    versions = get_source_document_versions(sqlite_path=sqlite_path, source_id="australia_institute")
+    assert len(versions) == 1
+
+
+def test_cli_limit_constrains_processing_scope(tmp_path: Path) -> None:
+    sqlite_path = tmp_path / "acquisition.db"
+    artifact_dir = tmp_path / "artifacts"
+    sitemap_path = tmp_path / "sitemap.xml"
+    sitemap_path.write_text(
+        """
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url><loc>https://australiainstitute.org.au/report-1</loc></url>
+          <url><loc>https://australiainstitute.org.au/report-2</loc></url>
+        </urlset>
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    output = StringIO()
+
+    exit_code = run_cli(
+        [
+            "acquire",
+            "--source",
+            "australia_institute",
+            "--sitemap-xml-path",
+            str(sitemap_path),
+            "--sqlite-path",
+            str(sqlite_path),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--limit",
+            "1",
+        ],
+        fetch_document=lambda _url: ("text/plain", b"Limited run content"),
+        stdout=output,
+    )
+
+    assert exit_code == 0
+    assert "processed_urls=1" in output.getvalue()
+
+    versions = get_source_document_versions(sqlite_path=sqlite_path, source_id="australia_institute")
+    assert len(versions) == 1
+
+
+def test_cli_dry_run_reports_discovery_without_persisting_state(tmp_path: Path) -> None:
+    sqlite_path = tmp_path / "acquisition.db"
+    artifact_dir = tmp_path / "artifacts"
+    sitemap_path = tmp_path / "sitemap.xml"
+    sitemap_path.write_text(
+        """
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+          <url><loc>https://australiainstitute.org.au/report-1</loc></url>
+          <url><loc>https://australiainstitute.org.au/report-2</loc></url>
+        </urlset>
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    output = StringIO()
+    fetch_calls: list[str] = []
+
+    def fetch_document(url: str) -> tuple[str, bytes]:
+        fetch_calls.append(url)
+        return "text/plain", b"Should not run in dry mode"
+
+    exit_code = run_cli(
+        [
+            "acquire",
+            "--source",
+            "australia_institute",
+            "--sitemap-xml-path",
+            str(sitemap_path),
+            "--sqlite-path",
+            str(sqlite_path),
+            "--artifact-dir",
+            str(artifact_dir),
+            "--dry-run",
+            "--limit",
+            "1",
+        ],
+        fetch_document=fetch_document,
+        stdout=output,
+    )
+
+    assert exit_code == 0
+    rendered = output.getvalue()
+    assert "dry_run" in rendered
+    assert "discovered_urls=1" in rendered
+    assert fetch_calls == []
+    assert not sqlite_path.exists()
+
+    versions = get_source_document_versions(sqlite_path=sqlite_path, source_id="australia_institute")
+    assert versions == []


### PR DESCRIPTION
## Summary
- add an operator-facing `acquire` CLI command with source selection, optional run limit, and explicit run output
- support dry-run execution that reports discovery scope without mutating persisted acquisition/document state
- wire CLI as the runtime entrypoint and extend integration coverage for source, limit, and dry-run behavior

Fixes #6