### PR TITLE
chore: align codebase with google python style

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,3 +159,11 @@ Each PR or handoff should state:
 - Prefer `uv sync` for environment synchronization and lockfile-aware dependency installation.
 - When adding dependencies, use `uv add <package>` (and `uv add --dev <package>` for dev-only tools).
 - Do not introduce `pip`/`requirements.txt`-based workflows, Poetry, or Pipenv for this repo.
+
+## 13) Commenting and docstring standard
+
+- Every function and method should include a short docstring explaining what it does in domain terms.
+- Prefer one to two lines in plain language; avoid restating the function name.
+- Focus on behavior and intent (`why/what`), not line-by-line implementation details (`how`).
+- Add argument/return detail only when it is non-obvious from type hints and naming.
+- Keep comments current: update docstrings whenever behavior changes.

--- a/ddd_policy_tracer/__init__.py
+++ b/ddd_policy_tracer/__init__.py
@@ -1,6 +1,12 @@
-from .domain import SourceDocumentVersion
-from .service_layer import AcquisitionReport, get_source_document_versions, ingest_source_documents
+"""Public package exports for document acquisition workflows."""
+
 from .cli import run_cli
+from .domain import SourceDocumentVersion
+from .service_layer import (
+    AcquisitionReport,
+    get_source_document_versions,
+    ingest_source_documents,
+)
 
 __all__ = [
     "AcquisitionReport",

--- a/ddd_policy_tracer/adapters.py
+++ b/ddd_policy_tracer/adapters.py
@@ -1,3 +1,5 @@
+"""Persistence and sitemap adapter implementations for acquisition flows."""
+
 from __future__ import annotations
 
 import sqlite3
@@ -9,14 +11,19 @@ from .domain import SourceDocumentVersion
 
 
 class SQLiteSourceDocumentRepository:
+    """Store and retrieve source document versions from SQLite."""
+
     def __init__(self, sqlite_path: Path) -> None:
+        """Bind the repository to a SQLite path and ensure schema readiness."""
         self._sqlite_path = sqlite_path
         self._initialize()
 
     def _connect(self) -> sqlite3.Connection:
+        """Open a new SQLite connection for repository operations."""
         return sqlite3.connect(self._sqlite_path)
 
     def _initialize(self) -> None:
+        """Create repository tables when they do not already exist."""
         with self._connect() as connection:
             connection.execute(
                 """
@@ -40,10 +47,12 @@ class SQLiteSourceDocumentRepository:
         source_id: str,
         source_document_id: str,
     ) -> SourceDocumentVersion | None:
+        """Return the latest persisted version for one source identity."""
         with self._connect() as connection:
             row = connection.execute(
                 """
-                SELECT source_id, source_document_id, source_url, checksum, normalized_text, raw_content_ref, content_type
+                SELECT source_id, source_document_id, source_url, checksum,
+                       normalized_text, raw_content_ref, content_type
                 FROM source_document_versions
                 WHERE source_id = ? AND source_document_id = ?
                 ORDER BY id DESC
@@ -58,11 +67,13 @@ class SQLiteSourceDocumentRepository:
         return SourceDocumentVersion(*row)
 
     def add_version(self, version: SourceDocumentVersion) -> None:
+        """Persist a new append-only source document version record."""
         with self._connect() as connection:
             connection.execute(
                 """
                 INSERT INTO source_document_versions
-                (source_id, source_document_id, source_url, checksum, normalized_text, raw_content_ref, content_type)
+                (source_id, source_document_id, source_url, checksum,
+                 normalized_text, raw_content_ref, content_type)
                 VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
@@ -77,10 +88,12 @@ class SQLiteSourceDocumentRepository:
             )
 
     def list_versions(self, *, source_id: str) -> list[SourceDocumentVersion]:
+        """List all persisted source document versions for a source."""
         with self._connect() as connection:
             rows = connection.execute(
                 """
-                SELECT source_id, source_document_id, source_url, checksum, normalized_text, raw_content_ref, content_type
+                SELECT source_id, source_document_id, source_url, checksum,
+                       normalized_text, raw_content_ref, content_type
                 FROM source_document_versions
                 WHERE source_id = ?
                 ORDER BY id ASC
@@ -92,19 +105,32 @@ class SQLiteSourceDocumentRepository:
 
 
 class DiskArtifactStore:
+    """Persist raw fetched artifacts to local disk storage."""
+
     def __init__(self, artifact_dir: Path) -> None:
+        """Prepare on-disk storage for raw fetched document artifacts."""
         self._artifact_dir = artifact_dir
         self._artifact_dir.mkdir(parents=True, exist_ok=True)
 
     def store(self, *, source_document_id: str, content: bytes) -> str:
-        safe_id = source_document_id.replace("://", "_").replace("/", "_").replace("?", "_")
+        """Write raw content to disk and return the artifact reference path."""
+        safe_id = (
+            source_document_id.replace("://", "_")
+            .replace("/", "_")
+            .replace("?", "_")
+        )
         file_path = self._artifact_dir / f"{safe_id}_{uuid4().hex}.bin"
         file_path.write_bytes(content)
         return str(file_path)
 
 
 def discover_urls_from_sitemap(sitemap_xml: str) -> list[str]:
+    """Extract document URLs from a sitemap URL set XML payload."""
     root = ET.fromstring(sitemap_xml)
     namespace = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
-    urls = [node.text.strip() for node in root.findall("sm:url/sm:loc", namespace) if node.text]
+    urls = [
+        node.text.strip()
+        for node in root.findall("sm:url/sm:loc", namespace)
+        if node.text
+    ]
     return urls

--- a/ddd_policy_tracer/cli.py
+++ b/ddd_policy_tracer/cli.py
@@ -1,9 +1,12 @@
+"""Operator CLI entrypoint and sitemap resolution helpers."""
+
 from __future__ import annotations
 
 import argparse
 import xml.etree.ElementTree as ET
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Callable, Sequence, TextIO
+from typing import TextIO
 
 from .service_layer import ingest_source_documents
 
@@ -15,6 +18,7 @@ def run_cli(
     stdout: TextIO,
     fetch_text_url: Callable[[str, str], str] | None = None,
 ) -> int:
+    """Execute operator CLI commands for manual acquisition runs."""
     parser = argparse.ArgumentParser(prog="ddd-policy-tracer")
     subparsers = parser.add_subparsers(dest="command")
 
@@ -45,7 +49,9 @@ def run_cli(
     )
 
     if args.dry_run:
-        discovered = _discover_urls_with_limit(sitemap_xml=sitemap_xml, limit=args.limit)
+        discovered = _discover_urls_with_limit(
+            sitemap_xml=sitemap_xml, limit=args.limit
+        )
         stdout.write(
             " ".join(
                 [
@@ -86,7 +92,10 @@ def run_cli(
     return 0
 
 
-def _discover_urls_with_limit(*, sitemap_xml: str, limit: int | None) -> list[str]:
+def _discover_urls_with_limit(
+    *, sitemap_xml: str, limit: int | None
+) -> list[str]:
+    """Discover URLs from sitemap XML and apply an optional upper bound."""
     from .adapters import discover_urls_from_sitemap
 
     urls = discover_urls_from_sitemap(sitemap_xml)
@@ -103,11 +112,14 @@ def _load_sitemap_xml(
     user_agent: str,
     fetch_text_url: Callable[[str, str], str] | None,
 ) -> tuple[str, int]:
+    """Load sitemap XML from local file or URL, resolving indexes as needed."""
     if sitemap_xml_path is not None:
         return Path(sitemap_xml_path).read_text(encoding="utf-8"), 1
 
     if sitemap_url is None:
-        raise ValueError("Either --sitemap-xml-path or --sitemap-url is required")
+        raise ValueError(
+            "Either --sitemap-xml-path or --sitemap-url is required"
+        )
 
     if fetch_text_url is None:
         raise ValueError("fetch_text_url is required when using --sitemap-url")
@@ -116,32 +128,43 @@ def _load_sitemap_xml(
     if _is_sitemap_index(root_xml):
         child_sitemaps = _discover_child_sitemaps(root_xml)
         if child_sitemap_pattern is not None:
-            child_sitemaps = [url for url in child_sitemaps if child_sitemap_pattern in url]
-        child_urlsets = [fetch_text_url(url, user_agent) for url in child_sitemaps]
+            child_sitemaps = [
+                url for url in child_sitemaps if child_sitemap_pattern in url
+            ]
+        child_urlsets = [
+            fetch_text_url(url, user_agent) for url in child_sitemaps
+        ]
         return _merge_urlsets(child_urlsets), len(child_sitemaps)
 
     return root_xml, 1
 
 
 def _is_sitemap_index(xml_text: str) -> bool:
+    """Return true when the XML payload is a sitemap index document."""
     root = ET.fromstring(xml_text)
     return root.tag.endswith("sitemapindex")
 
 
 def _discover_child_sitemaps(sitemap_index_xml: str) -> list[str]:
+    """Extract child sitemap URLs from a sitemap index document."""
     root = ET.fromstring(sitemap_index_xml)
     namespace = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
-    return [node.text.strip() for node in root.findall("sm:sitemap/sm:loc", namespace) if node.text]
+    return [
+        node.text.strip()
+        for node in root.findall("sm:sitemap/sm:loc", namespace)
+        if node.text
+    ]
 
 
 def _merge_urlsets(urlset_xml_documents: list[str]) -> str:
+    """Merge URL set documents into one deduplicated URL set XML payload."""
     urls: list[str] = []
     for xml_text in urlset_xml_documents:
         urls.extend(_discover_urls_with_limit(sitemap_xml=xml_text, limit=None))
 
     unique_urls = list(dict.fromkeys(urls))
     lines = [
-        "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">",
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
         *[f"  <url><loc>{url}</loc></url>" for url in unique_urls],
         "</urlset>",
     ]

--- a/ddd_policy_tracer/domain.py
+++ b/ddd_policy_tracer/domain.py
@@ -1,3 +1,5 @@
+"""Domain primitives and normalization rules for source documents."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -18,6 +20,8 @@ TRACKING_QUERY_KEYS = {
 
 @dataclass(frozen=True)
 class SourceDocumentVersion:
+    """Represent one append-only version snapshot of a source document."""
+
     source_id: str
     source_document_id: str
     source_url: str
@@ -28,6 +32,7 @@ class SourceDocumentVersion:
 
 
 def normalize_source_document_id(raw_url: str) -> str:
+    """Normalize a source URL into a stable source-scoped document identity."""
     parts = urlsplit(raw_url.strip())
     scheme = parts.scheme.lower()
     netloc = parts.netloc.lower()
@@ -48,8 +53,10 @@ def normalize_source_document_id(raw_url: str) -> str:
 
 
 def compute_checksum(raw_content: bytes) -> str:
+    """Compute a deterministic content hash for version change detection."""
     return sha256(raw_content).hexdigest()
 
 
 def normalize_text(raw_text: str) -> str:
+    """Apply minimal whitespace normalization to extracted document text."""
     return " ".join(raw_text.split())

--- a/ddd_policy_tracer/service_layer.py
+++ b/ddd_policy_tracer/service_layer.py
@@ -1,18 +1,32 @@
+"""Application service orchestration for document acquisition use cases."""
+
 from __future__ import annotations
 
 import inspect
 import time
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Literal, Sequence
+from typing import Literal
 from uuid import uuid4
 
-from .adapters import DiskArtifactStore, SQLiteSourceDocumentRepository, discover_urls_from_sitemap
-from .domain import SourceDocumentVersion, compute_checksum, normalize_source_document_id, normalize_text
+from .adapters import (
+    DiskArtifactStore,
+    SQLiteSourceDocumentRepository,
+    discover_urls_from_sitemap,
+)
+from .domain import (
+    SourceDocumentVersion,
+    compute_checksum,
+    normalize_source_document_id,
+    normalize_text,
+)
 
 
 @dataclass(frozen=True)
 class AcquisitionReport:
+    """Capture aggregate run results and emitted acquisition events."""
+
     run_id: str
     processed_urls: int
     ingested_documents: int
@@ -26,6 +40,8 @@ class AcquisitionReport:
 
 @dataclass(frozen=True)
 class AcquisitionEvent:
+    """Represent one domain event emitted during an acquisition run."""
+
     event_type: Literal[
         "AcquisitionRunStarted",
         "SourceDocumentIngested",
@@ -36,7 +52,9 @@ class AcquisitionEvent:
     source_id: str
     source_url: str | None = None
     source_document_id: str | None = None
-    run_status: Literal["completed", "completed_with_failures", "failed"] | None = None
+    run_status: (
+        Literal["completed", "completed_with_failures", "failed"] | None
+    ) = None
 
 
 def ingest_source_documents(
@@ -53,6 +71,7 @@ def ingest_source_documents(
     sleep_fn: Callable[[float], None] = time.sleep,
     limit: int | None = None,
 ) -> AcquisitionReport:
+    """Ingest discovered URLs and return aggregate acquisition outcomes."""
     repository = SQLiteSourceDocumentRepository(sqlite_path)
     artifact_store = DiskArtifactStore(artifact_dir)
 
@@ -106,7 +125,10 @@ def ingest_source_documents(
                 source_id=source_id,
                 source_document_id=source_document_id,
             )
-            if latest_version is not None and latest_version.checksum == checksum:
+            if (
+                latest_version is not None
+                and latest_version.checksum == checksum
+            ):
                 continue
 
             raw_content_ref = artifact_store.store(
@@ -147,7 +169,9 @@ def ingest_source_documents(
             )
 
     if failed_documents == 0:
-        run_status: Literal["completed", "completed_with_failures", "failed"] = "completed"
+        run_status: Literal[
+            "completed", "completed_with_failures", "failed"
+        ] = "completed"
     elif ingested_documents == 0:
         run_status = "failed"
     else:
@@ -180,6 +204,7 @@ def get_source_document_versions(
     sqlite_path: Path,
     source_id: str,
 ) -> list[SourceDocumentVersion]:
+    """Load persisted source document versions for one source."""
     repository = SQLiteSourceDocumentRepository(sqlite_path)
     return repository.list_versions(source_id=source_id)
 
@@ -190,6 +215,7 @@ def _call_fetch_document(
     source_url: str,
     user_agent: str,
 ) -> tuple[str, bytes]:
+    """Call the fetcher using supported URL-only or URL+agent signatures."""
     signature = inspect.signature(fetch_document)
     if len(signature.parameters) >= 2:
         return fetch_document(source_url, user_agent)
@@ -205,6 +231,7 @@ def _fetch_with_retries(
     backoff_seconds: Sequence[float],
     sleep_fn: Callable[[float], None],
 ) -> tuple[str, bytes, int]:
+    """Fetch one source URL with bounded retries for transient failures."""
     retries_used = 0
 
     while True:

--- a/main.py
+++ b/main.py
@@ -1,13 +1,17 @@
+"""Runtime bootstrap for the operator acquisition CLI."""
+
 from __future__ import annotations
 
 import sys
-from typing import Sequence, cast
+from collections.abc import Sequence
+from typing import cast
 from urllib.request import Request, urlopen
 
 from ddd_policy_tracer.cli import run_cli
 
 
 def main(argv: Sequence[str] | None = None) -> int:
+    """Run the CLI entrypoint and return a process exit code."""
     args = list(sys.argv[1:] if argv is None else argv)
     return run_cli(
         args,
@@ -18,14 +22,18 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 def fetch_document_over_http(url: str, user_agent: str) -> tuple[str, bytes]:
+    """Fetch one document over HTTP with a configured user-agent header."""
     request = Request(url, headers={"User-Agent": user_agent})
     with urlopen(request, timeout=30) as response:
-        content_type = response.headers.get_content_type() or "application/octet-stream"
+        content_type = (
+            response.headers.get_content_type() or "application/octet-stream"
+        )
         payload = response.read()
     return content_type, payload
 
 
 def fetch_text_url(url: str, user_agent: str) -> str:
+    """Fetch a text URL payload, used for sitemap document retrieval."""
     request = Request(url, headers={"User-Agent": user_agent})
     with urlopen(request, timeout=30) as response:
         payload = cast(bytes, response.read())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,14 @@ dev = [
 ]
 
 [tool.ruff]
-line-length = 100
+line-length = 80
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "D", "UP", "B"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.mypy]
 python_version = "3.12"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Legacy source package namespace for repository scaffolding."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Pytest configuration for repository-local import resolution."""
+
 from __future__ import annotations
 
 import sys

--- a/tests/integration/test_acquisition_core.py
+++ b/tests/integration/test_acquisition_core.py
@@ -1,9 +1,17 @@
+"""Integration tests for core acquisition service behavior."""
+
 from pathlib import Path
 
-from ddd_policy_tracer import get_source_document_versions, ingest_source_documents
+from ddd_policy_tracer import (
+    get_source_document_versions,
+    ingest_source_documents,
+)
 
 
-def test_ingest_from_sitemap_persists_first_source_document_version(tmp_path: Path) -> None:
+def test_ingest_from_sitemap_persists_first_source_document_version(
+    tmp_path: Path,
+) -> None:
+    """Verify one sitemap URL is ingested and persisted with artifact data."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     sitemap_xml = """
@@ -36,13 +44,17 @@ def test_ingest_from_sitemap_persists_first_source_document_version(tmp_path: Pa
 
     assert len(versions) == 1
     version = versions[0]
-    assert version.source_document_id == "https://australiainstitute.org.au/report-1"
+    assert (
+        version.source_document_id
+        == "https://australiainstitute.org.au/report-1"
+    )
     assert version.normalized_text == "This is a report about policy reform."
     assert version.raw_content_ref.startswith(str(artifact_dir))
     assert Path(version.raw_content_ref).exists()
 
 
 def test_reprocessing_same_unchanged_url_is_idempotent(tmp_path: Path) -> None:
+    """Ensure unchanged content does not create duplicate persisted versions."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     sitemap_xml = """
@@ -72,11 +84,14 @@ def test_reprocessing_same_unchanged_url_is_idempotent(tmp_path: Path) -> None:
     assert first_report.ingested_documents == 1
     assert second_report.ingested_documents == 0
 
-    versions = get_source_document_versions(sqlite_path=sqlite_path, source_id="australia_institute")
+    versions = get_source_document_versions(
+        sqlite_path=sqlite_path, source_id="australia_institute"
+    )
     assert len(versions) == 1
 
 
 def test_checksum_change_appends_new_version(tmp_path: Path) -> None:
+    """Ensure checksum changes append a new version for the same identity."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     sitemap_xml = """
@@ -110,12 +125,17 @@ def test_checksum_change_appends_new_version(tmp_path: Path) -> None:
 
     assert second_report.ingested_documents == 1
 
-    versions = get_source_document_versions(sqlite_path=sqlite_path, source_id="australia_institute")
+    versions = get_source_document_versions(
+        sqlite_path=sqlite_path, source_id="australia_institute"
+    )
     assert len(versions) == 2
     assert versions[0].checksum != versions[1].checksum
 
 
-def test_run_status_is_completed_with_failures_for_mixed_outcomes(tmp_path: Path) -> None:
+def test_run_status_is_completed_with_failures_for_mixed_outcomes(
+    tmp_path: Path,
+) -> None:
+    """Report mixed run outcomes as completed_with_failures."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     sitemap_xml = """
@@ -145,6 +165,7 @@ def test_run_status_is_completed_with_failures_for_mixed_outcomes(tmp_path: Path
 
 
 def test_run_status_is_failed_when_all_urls_fail(tmp_path: Path) -> None:
+    """Report run status failed when every processed URL fails."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     sitemap_xml = """
@@ -171,7 +192,10 @@ def test_run_status_is_failed_when_all_urls_fail(tmp_path: Path) -> None:
     assert report.run_status == "failed"
 
 
-def test_compliance_blocks_disallowed_url_and_uses_configured_user_agent(tmp_path: Path) -> None:
+def test_compliance_blocks_disallowed_url_and_uses_configured_user_agent(
+    tmp_path: Path,
+) -> None:
+    """Skip disallowed URLs and pass user-agent into compliant fetch calls."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     sitemap_xml = """
@@ -211,6 +235,7 @@ def test_compliance_blocks_disallowed_url_and_uses_configured_user_agent(tmp_pat
 
 
 def test_transient_failure_is_retried_and_observable(tmp_path: Path) -> None:
+    """Retry transient fetch failures and expose retry attempts in report."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     sitemap_xml = """
@@ -248,9 +273,10 @@ def test_transient_failure_is_retried_and_observable(tmp_path: Path) -> None:
     assert report.retry_attempts == 2
 
 
-def test_terminal_failure_records_actionable_reason_after_retry_budget_exhausted(
+def test_terminal_failure_records_actionable_reason_after_retries_exhausted(
     tmp_path: Path,
 ) -> None:
+    """Record actionable failure details after retries are exhausted."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     sitemap_xml = """
@@ -287,7 +313,10 @@ def test_terminal_failure_records_actionable_reason_after_retry_budget_exhausted
     assert "request timeout" in report.document_failures[0]
 
 
-def test_domain_events_are_emitted_in_expected_lifecycle_sequence(tmp_path: Path) -> None:
+def test_domain_events_are_emitted_in_expected_lifecycle_sequence(
+    tmp_path: Path,
+) -> None:
+    """Emit ordered run/document lifecycle events with run context."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     sitemap_xml = """
@@ -317,7 +346,15 @@ def test_domain_events_are_emitted_in_expected_lifecycle_sequence(tmp_path: Path
         "AcquisitionRunCompleted",
     ]
     assert all(event.run_id == report.run_id for event in report.events)
-    assert all(event.source_id == "australia_institute" for event in report.events)
-    assert report.events[1].source_url == "https://australiainstitute.org.au/event-ok"
-    assert report.events[2].source_url == "https://australiainstitute.org.au/event-fail"
+    assert all(
+        event.source_id == "australia_institute" for event in report.events
+    )
+    assert (
+        report.events[1].source_url
+        == "https://australiainstitute.org.au/event-ok"
+    )
+    assert (
+        report.events[2].source_url
+        == "https://australiainstitute.org.au/event-fail"
+    )
     assert report.events[3].run_status == "completed_with_failures"

--- a/tests/integration/test_operator_cli.py
+++ b/tests/integration/test_operator_cli.py
@@ -1,3 +1,5 @@
+"""Integration tests for operator CLI acquisition execution paths."""
+
 from __future__ import annotations
 
 from io import StringIO
@@ -7,7 +9,10 @@ from ddd_policy_tracer import get_source_document_versions
 from ddd_policy_tracer.cli import run_cli
 
 
-def test_cli_runs_manual_acquisition_for_source_and_prints_result(tmp_path: Path) -> None:
+def test_cli_runs_manual_acquisition_for_source_and_prints_result(
+    tmp_path: Path,
+) -> None:
+    """Run CLI acquisition and verify persisted output and rendered summary."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     sitemap_path = tmp_path / "sitemap.xml"
@@ -43,11 +48,14 @@ def test_cli_runs_manual_acquisition_for_source_and_prints_result(tmp_path: Path
     assert "source=australia_institute" in rendered
     assert "run_status=completed" in rendered
 
-    versions = get_source_document_versions(sqlite_path=sqlite_path, source_id="australia_institute")
+    versions = get_source_document_versions(
+        sqlite_path=sqlite_path, source_id="australia_institute"
+    )
     assert len(versions) == 1
 
 
 def test_cli_limit_constrains_processing_scope(tmp_path: Path) -> None:
+    """Ensure CLI limit flag caps processed sitemap URLs."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     sitemap_path = tmp_path / "sitemap.xml"
@@ -84,11 +92,16 @@ def test_cli_limit_constrains_processing_scope(tmp_path: Path) -> None:
     assert exit_code == 0
     assert "processed_urls=1" in output.getvalue()
 
-    versions = get_source_document_versions(sqlite_path=sqlite_path, source_id="australia_institute")
+    versions = get_source_document_versions(
+        sqlite_path=sqlite_path, source_id="australia_institute"
+    )
     assert len(versions) == 1
 
 
-def test_cli_dry_run_reports_discovery_without_persisting_state(tmp_path: Path) -> None:
+def test_cli_dry_run_reports_discovery_without_persisting_state(
+    tmp_path: Path,
+) -> None:
+    """Ensure dry-run reports discovery without fetching or persistence."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     sitemap_path = tmp_path / "sitemap.xml"
@@ -135,11 +148,16 @@ def test_cli_dry_run_reports_discovery_without_persisting_state(tmp_path: Path) 
     assert fetch_calls == []
     assert not sqlite_path.exists()
 
-    versions = get_source_document_versions(sqlite_path=sqlite_path, source_id="australia_institute")
+    versions = get_source_document_versions(
+        sqlite_path=sqlite_path, source_id="australia_institute"
+    )
     assert versions == []
 
 
-def test_cli_can_resolve_sitemap_index_using_child_pattern(tmp_path: Path) -> None:
+def test_cli_can_resolve_sitemap_index_using_child_pattern(
+    tmp_path: Path,
+) -> None:
+    """Resolve sitemap index URLs and ingest matching child sitemap entries."""
     sqlite_path = tmp_path / "acquisition.db"
     artifact_dir = tmp_path / "artifacts"
     output = StringIO()
@@ -190,5 +208,7 @@ def test_cli_can_resolve_sitemap_index_using_child_pattern(tmp_path: Path) -> No
     assert exit_code == 0
     assert "processed_urls=1" in output.getvalue()
 
-    versions = get_source_document_versions(sqlite_path=sqlite_path, source_id="australia_institute")
+    versions = get_source_document_versions(
+        sqlite_path=sqlite_path, source_id="australia_institute"
+    )
     assert len(versions) == 1


### PR DESCRIPTION
## Summary
- configure Ruff for Google-style enforcement with 80-char lines, Google docstring convention, and stricter lint rule selection
- add repository-level commenting/docstring standard guidance in AGENTS and apply concise docstrings across runtime and test modules
- reformat imports and line wrapping to satisfy the updated style checks while keeping tests and typing green